### PR TITLE
Use updated SdkTarget in core/AMBuilder

### DIFF
--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -1,7 +1,10 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python: 
 import os
 
-for sdk, cxx in MMS.sdk_targets:
+for sdk_target in MMS.sdk_targets:
+  sdk = sdk_target.sdk
+  cxx = sdk_target.cxx
+
   name = 'metamod.' + sdk['extension']
   binary = MMS.HL2Library(builder, cxx, name, sdk)
 


### PR DESCRIPTION
1.12's core AMBuilder script was not updated to handle the recent changes to the manifest's SdkHelpers script as per https://github.com/alliedmodders/hl2sdk-manifests/commit/fded652931187ed7359ed75037b939ae5654cc0e.